### PR TITLE
fix, Remove race condition bug with bttv.

### DIFF
--- a/src/modules/emotes.js
+++ b/src/modules/emotes.js
@@ -116,7 +116,6 @@ function EmoteStore() {
 		}
 		logger.debug('Getter registered: ' + name);
 		getters[name] = getter;
-		ui.updateEmotes();
 	};
 
 	/**


### PR DESCRIPTION
This line I removed, is throwing an error if a getter is registered as soon as the script is injected (like BTTV do), and it breaks getting regular twitch emotes.

This change doesn't break the behavior as the getter is called when the emote menu gets opened.